### PR TITLE
Adapt icon path removal from core

### DIFF
--- a/src/main/resources/com/vmware/devops/plugins/wavefront/WavefrontManagement/index.jelly
+++ b/src/main/resources/com/vmware/devops/plugins/wavefront/WavefrontManagement/index.jelly
@@ -4,7 +4,7 @@
     <l:layout title="${%Wavefront plugin configuration}" norefresh="true" permission="false">
         <l:side-panel>
             <l:tasks>
-                <l:task icon="images/24x24/up.gif" href="${rootURL}/" title="${%Back to Dashboard}"/>
+                <l:task icon="icon-up icon-md" href="${rootURL}/" title="${%Back to Dashboard}"/>
             </l:tasks>
         </l:side-panel>
         <l:main-panel>


### PR DESCRIPTION
The change proposed prepares the plugin for the icon path removal from core in the upcoming LTS line. This change affects plugins not using the icon API or relying on paths. Plugins using the API properly in the first place are unaffected by this change.
In case of your plugin, I've removed the header icons, because that is what modern Jenkins does now look like.

Could you trigger a release after merging this PR please, giving people a chance to update the plugin before updating to the next LTS version @dparapanov 
Thanks in advance!